### PR TITLE
Support utf8mb4

### DIFF
--- a/lib/DB/SQL/Migrations.pm
+++ b/lib/DB/SQL/Migrations.pm
@@ -112,7 +112,7 @@ sub create_migrations_table {
   my $date_field = $self->schema_migrations_date_field;
 
   my $sql = "CREATE TABLE IF NOT EXISTS $table_name (
-                $name_field varchar(255) NOT NULL PRIMARY KEY,
+                $name_field varchar(255) CHARACTER SET latin1 NOT NULL PRIMARY KEY,
                 $date_field datetime NOT NULL
              );   
   ";


### PR DESCRIPTION
When running `create_migrations_table()` on a database with a utf8mb4 default collation, it fails with
```
DBD::mysql::db do failed: Specified key was too long; max key length is 767 bytes at /usr/local/share/perl5/DB/SQL/Migrations.pm line 120.
```

This is because the length is primary key is too long, VARCHAR(255) with 4-byte characters = 1020 bytes, longer than the maximum length for a primary key, which is 767 bytes.

The fix is to enforce `latin1` charset on the column with 1 byte per character. to ensure the length of the primary key is only 255 bytes.